### PR TITLE
change usage of namespace for the example.

### DIFF
--- a/src/bcrypt.hpp
+++ b/src/bcrypt.hpp
@@ -70,9 +70,9 @@ namespace Bcrypt
  *	char hash[BCRYPT_HASHSIZE];
  *	int ret;
  *
- *	ret = Bcrypt.gensalt(12, salt);
+ *	ret = Bcrypt::gensalt(12, salt);
  *	assert(ret == 0);
- *	ret = Bcrypt.hashpw("thepassword", salt, hash);
+ *	ret = Bcrypt::hashpw("thepassword", salt, hash);
  *	assert(ret == 0);
  *
  *
@@ -80,7 +80,7 @@ namespace Bcrypt
  *
  *	int ret;
  *
- *      ret = Bcrypt.checkpw("thepassword", "expectedhash");
+ *      ret = Bcrypt::checkpw("thepassword", "expectedhash");
  *      assert(ret != -1);
  *
  *	if (ret == 0) {


### PR DESCRIPTION
ret = Bcrypt.gensalt(12, salt);
ret = Bcrypt.hashpw("thepassword", salt, hash);
ret = Bcrypt.checkpw("thepassword", "expectedhash");

Above turn in to below
ret = Bcrypt::gensalt(12, salt);
ret = Bcrypt::hashpw("thepassword", salt, hash);
ret = Bcrypt::checkpw("thepassword", "expectedhash");

Because the "." between namespace and function return "error expected primary-expression before ' .' token"
after putting "::" everythings goes well .

another addition, while using assert(...)  you have to use #include <assert.h> to complie.